### PR TITLE
Fix broken parsing on get subscription list

### DIFF
--- a/src/Univapay/Utility/FormatterUtils.php
+++ b/src/Univapay/Utility/FormatterUtils.php
@@ -67,7 +67,8 @@ class FormatterUtils
     {
         return function (array $values, $json = null, $parent = null) use ($schemaParser) {
             $curriedParser = function ($value) use ($schemaParser, $json, $parent) {
-                return call_user_func($schemaParser, $value, $json, $parent);
+                // Pass the item as the contextRoot instead of the whole paginated json as that is expected
+                return call_user_func($schemaParser, $value, $value);
             };
             return array_map($curriedParser, $values);
         };

--- a/tests/Univapay/Integration/Requests.php
+++ b/tests/Univapay/Integration/Requests.php
@@ -295,6 +295,27 @@ trait Requests
             ->awaitResult();
     }
     
+
+    public function createValidFixedAmountInstallmentSubscription()
+    {
+        $this->deactivateExistingSubscriptionToken();
+        $installmentPlan = new InstallmentPlan(
+            InstallmentPlanType::FIXED_CYCLE_AMOUNT(),
+            null,
+            Money::JPY(1000)
+        );
+        return $this
+            ->createValidToken(PaymentType::CARD(), TokenType::SUBSCRIPTION())
+            ->createSubscription(
+                Money::JPY(10000),
+                Period::BIWEEKLY(),
+                Money::JPY(1000),
+                null,
+                $installmentPlan
+            )
+            ->awaitResult();
+    }
+    
     public function createUnconfirmedSubscription()
     {
         $this->deactivateExistingSubscriptionToken();

--- a/tests/Univapay/Integration/SubscriptionTest.php
+++ b/tests/Univapay/Integration/SubscriptionTest.php
@@ -144,6 +144,13 @@ EOD;
         $this->assertInstanceOf(ScheduledPayment::class, $subscription->nextPayment);
     }
 
+    public function testCreateFixedAmountInstallmentSubscription()
+    {
+        $subscription = $this->createValidFixedAmountInstallmentSubscription();
+        $this->assertEquals(InstallmentPlanType::FIXED_CYCLE_AMOUNT(), $subscription->installmentPlan->planType);
+        $this->assertEquals(Money::JPY(1000), $subscription->installmentPlan->fixedCycleAmount);
+    }
+
     public function testGetSubscription()
     {
         $subscription = $this->createValidSubscription();


### PR DESCRIPTION
It breaks when using the formatter feature which fetches values from the parent and only on paginated lists