### PR TITLE
Add bank transfer enum to payment type

### DIFF
--- a/src/Univapay/Enums/PaymentType.php
+++ b/src/Univapay/Enums/PaymentType.php
@@ -12,4 +12,5 @@ final class PaymentType extends TypedEnum
     public static function APPLE_PAY() { return self::create(); }
     public static function PAIDY() { return self::create(); }
     public static function ONLINE() { return self::create(); }
+    public static function BANK_TRANSFER() { return self::create(); }
 }


### PR DESCRIPTION
This only supports tokens that have been created by the widget and does not fully supporting creating bank transfer tokens via the SDK
