### PR TITLE
Fix charge list metadata search as string and add tx history metadata search

### DIFF
--- a/src/Univapay/Resources/Mixins/GetCharges.php
+++ b/src/Univapay/Resources/Mixins/GetCharges.php
@@ -31,7 +31,7 @@ trait GetCharges
         $amountFrom = null,
         $amountTo = null,
         Currency $currency = null,
-        array $metadata = null,
+        $metadata = null,
         AppTokenMode $mode = null,
         $transactionTokenId = null,
         $gatewayCredentialsId = null,
@@ -72,7 +72,6 @@ trait GetCharges
             'from' => 'ValidationHelper::getAtomDate',
             'to' => 'ValidationHelper::getAtomDate',
             'currency' => 'ValidationHelper::getEnumValue',
-            'metadata' => 'ValidationHelper::isArray',
             'mode' => 'ValidationHelper::getEnumValue',
             'cursor_direction' => 'ValidationHelper::getEnumValue',
         ];

--- a/src/Univapay/Resources/Mixins/GetTransactionTokens.php
+++ b/src/Univapay/Resources/Mixins/GetTransactionTokens.php
@@ -23,7 +23,7 @@ trait GetTransactionTokens
 
     public function listTransactionTokens(
         $search = null,
-        $UnivapayCustomerId = null,
+        $univapayCustomerId = null,
         TokenType $type = null,
         AppTokenMode $mode = null,
         ActiveFilter $active = null,
@@ -39,7 +39,7 @@ trait GetTransactionTokens
         $query = FunctionalUtils::stripNulls([
             'search' => $search,
             'active' => isset($active) ? $active->getValue() : null,
-            'customer_id' => $UnivapayCustomerId,
+            'customer_id' => $univapayCustomerId,
             'type' => isset($type) ? $type->getValue() : null,
             'mode' => isset($mode) ? $mode->getValue() : null,
             'cursor' => $cursor,

--- a/src/Univapay/Resources/Mixins/GetTransactions.php
+++ b/src/Univapay/Resources/Mixins/GetTransactions.php
@@ -27,6 +27,7 @@ trait GetTransactions
         AppTokenMode $mode = null,
         $gatewayCredentialsId = null,
         $gatewayTransactionId = null,
+        $metadata = null,
         $cursor = null,
         $limit = null,
         CursorDirection $cursorDirection = null
@@ -38,6 +39,7 @@ trait GetTransactions
             'type' => isset($type) ? $type->getValue() : null,
             'search' => $search,
             'mode' => isset($mode) ? $mode->getValue() : null,
+            'metadata' => $metadata,
             'cursor' => $cursor,
             'limit' => $limit,
             'cursor_direction' => isset($cursorDirection) ? $cursorDirection.getValue() : null


### PR DESCRIPTION
Closes #51

Remove array restriction on charge list `metadata` filter and add `metadata` search filter on transactions