### PR TITLE
Fix Sending 3DS Parameters on UnivapayClient

### DIFF
--- a/src/Univapay/UnivapayClient.php
+++ b/src/Univapay/UnivapayClient.php
@@ -216,6 +216,10 @@ class UnivapayClient
                 $subscriptionPlan,
                 $installmentPlan,
                 $metadata,
+                null, // only direct currency
+                null, // first charge authorization only
+                null, // first charge capture after
+                null, // cyclical period
                 $paymentThreeDS
             );
     }


### PR DESCRIPTION
Closes #79 

We misses the bug, because the automated test is using an inner class for PaymentThreeDS, rather than the outer class that is actually used by the UnivapayClient. This mismatch caused the 3DS parameters to not be properly passed during subscription creation.

However, the current test structure needs improvement.
In the future, plan to refactor the tests to better align with the actual implementation and avoid such discrepancies.